### PR TITLE
Fix pack compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 StackStorm Pack to automate various operations related to Mistral development, tesing and relase
 
 Used in [`st2cd`](https://github.com/StackStorm/st2cd) workflows.
+
+Extracted from [`st2incubator mistral-dev`](https://github.com/StackStorm/st2incubator/tree/master/packs/mistral-dev)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mistral_dev
 StackStorm Pack to automate various operations related to Mistral development, tesing and relase
 
-Used in [`st2cd`](https://github.com/StackStorm/st2cd) workflows.
+Used in [`st2ci`](https://github.com/StackStorm/st2ci) workflows.
 
 Extracted from [`st2incubator mistral-dev`](https://github.com/StackStorm/st2incubator/tree/master/packs/mistral-dev)

--- a/actions/stress.yaml
+++ b/actions/stress.yaml
@@ -1,6 +1,6 @@
 {
     "name": "stress",
-    "pack": "mistral-dev",
+    "pack": "mistral_dev",
     "runner_type": "run-python",
     "description": "Action to stress test  mistral.",
     "enabled": true,

--- a/actions/switch.yaml
+++ b/actions/switch.yaml
@@ -1,6 +1,6 @@
 ---
 name: switch
-pack: mistral-dev
+pack: mistral_dev
 runner_type: run-local-script
 description: Switch between the stackstorm/mistral and stackforge/mistral repo for development.
 enabled: true

--- a/actions/which.yaml
+++ b/actions/which.yaml
@@ -1,6 +1,6 @@
 ---
 name: "which"
-pack: "mistral-dev"
+pack: "mistral_dev"
 runner_type: "run-local-script"
 description: "Return which mistral repo is currently set for development."
 enabled: true

--- a/actions/workflows/setup.chain.yaml
+++ b/actions/workflows/setup.chain.yaml
@@ -32,7 +32,7 @@ chain:
         on-success: "install"
     -
         name: "install"
-        ref: "mistral-dev.install"
+        ref: "mistral_dev.install"
         params:
             hosts: "{{host}}"
             repo_main: "{{clone_mistral[host].stdout}}"
@@ -41,7 +41,7 @@ chain:
         on-success: "setup_config"
     -
         name: "setup_config"
-        ref: "mistral-dev.setup_config"
+        ref: "mistral_dev.setup_config"
         params:
             hosts: "{{host}}"
             mistral_path: "{{clone_mistral[host].stdout}}"
@@ -53,7 +53,7 @@ chain:
         on-success: "setup_db"
     -
         name: "setup_db"
-        ref: "mistral-dev.setup_db"
+        ref: "mistral_dev.setup_db"
         params:
             hosts: "{{host}}"
             mistral_path: "{{clone_mistral[host].stdout}}"
@@ -66,7 +66,7 @@ chain:
         on-success: "setup_service"
     -
         name: "setup_service"
-        ref: "mistral-dev.setup_service"
+        ref: "mistral_dev.setup_service"
         params:
             hosts: "{{host}}"
             distro: "{{distro}}"

--- a/actions/workflows/setup.mistral.yaml
+++ b/actions/workflows/setup.mistral.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-mistral-dev.setup:
+mistral_dev.setup:
     description: Setup a running instance of Mistral from git repo.
     type: direct
     input:
@@ -50,7 +50,7 @@ mistral-dev.setup:
                 - install
 
         install:
-            action: mistral-dev.install
+            action: mistral_dev.install
             input:
                 hosts: <% $.host %>
                 repo_main: <% $.clone_paths.get(mistral) %>
@@ -60,7 +60,7 @@ mistral-dev.setup:
                 - setup_config
 
         setup_config:
-            action: mistral-dev.setup_config
+            action: mistral_dev.setup_config
             input:
                 hosts: <% $.host %>
                 mistral_path: <% $.clone_paths.get(mistral) %>
@@ -73,7 +73,7 @@ mistral-dev.setup:
                 - setup_db
 
         setup_db:
-            action: mistral-dev.setup_db
+            action: mistral_dev.setup_db
             input:
                 hosts: <% $.host %>
                 mistral_path: <% $.clone_paths.get(mistral) %>
@@ -88,7 +88,7 @@ mistral-dev.setup:
                 - setup_api_server
 
         setup_service:
-            action: mistral-dev.setup_service
+            action: mistral_dev.setup_service
             input:
                 hosts: <% $.host %>
                 distro: <% $.distro %>
@@ -103,7 +103,7 @@ mistral-dev.setup:
                 cmd: service mistral start
 
         setup_api_server:
-            action: mistral-dev.setup_api_server
+            action: mistral_dev.setup_api_server
             input:
                 hosts: <% $.host %>
                 distro: <% $.distro %>
@@ -120,7 +120,7 @@ mistral-dev.setup:
 
         # Declare error handler(s) here
         teardown:
-            action: mistral-dev.teardown
+            action: mistral_dev.teardown
             input:
                 host: <% $.host %>
                 distro: <% $.distro %>

--- a/actions/workflows/teardown.chain.yaml
+++ b/actions/workflows/teardown.chain.yaml
@@ -11,14 +11,14 @@ chain:
         on-failure: "uninstall"
     -
         name: "uninstall"
-        ref: "mistral-dev.uninstall"
+        ref: "mistral_dev.uninstall"
         params:
             hosts: "{{host}}"
             distro: "{{distro}}"
         on-success: "teardown_db"
     -
         name: "teardown_db"
-        ref: "mistral-dev.teardown_db"
+        ref: "mistral_dev.teardown_db"
         params:
             hosts: "{{host}}"
             db_type: "{{db_type}}"

--- a/actions/workflows/teardown.mistral.yaml
+++ b/actions/workflows/teardown.mistral.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-mistral-dev.teardown:
+mistral_dev.teardown:
     description: Teardown a running instance of Mistral.
     type: direct
     input:
@@ -38,13 +38,13 @@ mistral-dev.teardown:
                 - remove_repos
 
         uninstall:
-            action: mistral-dev.uninstall
+            action: mistral_dev.uninstall
             input:
                 hosts: <% $.host %>
                 distro: <% $.distro %>
 
         teardown_db:
-            action: mistral-dev.teardown_db
+            action: mistral_dev.teardown_db
             input:
                 hosts: <% $.host %>
                 db_type: <% $.db_type %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,5 +1,6 @@
 ---
 name : mistral_dev
+ref: mistral_dev
 description : st2 content pack for mistral development.
 version : 0.1
 author : st2-dev

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,5 +1,5 @@
 ---
-name : mistral-dev
+name : mistral_dev
 description : st2 content pack for mistral development.
 version : 0.1
 author : st2-dev


### PR DESCRIPTION
The pack transferred from https://github.com/StackStorm/st2incubator/tree/master/packs/mistral-dev is outdated and has compatibility issues when running in recent st2 version.