### PR TITLE
Remove obsolete hack, this line doesn't match anything anymore

### DIFF
--- a/actions/install.sh
+++ b/actions/install.sh
@@ -34,7 +34,6 @@ pip install "amqp>=1.4.0,<2.0.0"
 
 # Setup mistral.
 cd ${REPO_MAIN}
-sed -i 's/yaql>=0.2.7,!=0.3.0/yaql>=0.2.7,!=0.3.0,<1.0.0/g' requirements.txt
 pip install -q -r requirements.txt
 pip install gunicorn
 


### PR DESCRIPTION
This sed line doesn't match anything anymore since we now use new YAQL version - https://github.com/StackStorm/mistral/blob/master/requirements.txt#L58