### PR TITLE
Fix/mistral build failure

### DIFF
--- a/actions/install.sh
+++ b/actions/install.sh
@@ -41,6 +41,7 @@ cd ${REPO_MAIN}
 grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
 sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
+sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0 # BSD/g" requirements.txt
 
 pip install -q -r requirements.txt
 

--- a/actions/install.sh
+++ b/actions/install.sh
@@ -35,7 +35,6 @@ pip install "amqp>=1.4.0,<2.0.0"
 
 # Setup mistral.
 cd ${REPO_MAIN}
-sed -i 's/yaql>=0.2.7,!=0.3.0/yaql>=0.2.7,!=0.3.0,<1.0.0/g' requirements.txt
 pip install -q -r requirements.txt
 pip install gunicorn
 

--- a/actions/install.sh
+++ b/actions/install.sh
@@ -35,8 +35,13 @@ pip install "amqp>=1.4.0,<2.0.0"
 
 # Setup mistral.
 cd ${REPO_MAIN}
+# NB! Sync 'requirements.txt' replacements with recent injects in 'st2-packages'
+# Latest: https://github.com/StackStorm/st2-packages/blob/9535deee32bc121a601c9bb885c49cec22cd6022/packages/st2mistral/Makefile#L74-L77
+grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
+grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
+sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
+
 pip install -q -r requirements.txt
-pip install gunicorn
 
 # Temporary hack to bypass conflict in pbr version.
 VENV_PKG_DIR="${REPO_MAIN}/.venv/local/lib/python2.7/site-packages"


### PR DESCRIPTION
Error on `mistral` `python setup.py develop`: 
```
error: Babel 2.4.0 is installed but Babel!=2.4.0,>=2.3.4 is required by set(['oslo.i18n', 'python-novaclient', 'python-magnumclient', 'python-neutronclient', 'python-openstackclient', 'python-heatclient', 'python-troveclient', 'python-muranoclient', 'python-senlinclient', 'osc-lib', 'python-glanceclient', 'python-cinderclient'])
```

The fix is to sync with recent `st2-packages` hacks: https://github.com/StackStorm/st2-packages/blob/9535deee32bc121a601c9bb885c49cec22cd6022/packages/st2mistral/Makefile#L74-L77 we made.