### PR TITLE
Update pack semver

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 name : mistral_dev
 ref: mistral_dev
 description : st2 content pack for mistral development.
-version : 0.1
+version : 0.2.0
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
Fix
```
2017-06-16 15:29:00,820 WARNING [-] Pack "mistral_dev" contains invalid semver version specifer, casting it to a full semver version specifier (0.1 -> 0.1.0).
Short versions will become INVALID in StackStorm 2.2, and the pack will stop working. Update the pack version in "pack.yaml".
```