### PR TITLE
Fix pika dependency for mistral install

### DIFF
--- a/actions/install.sh
+++ b/actions/install.sh
@@ -40,6 +40,7 @@ cd ${REPO_MAIN}
 # Latest: https://github.com/StackStorm/st2-packages/blob/9535deee32bc121a601c9bb885c49cec22cd6022/packages/st2mistral/Makefile#L74-L77
 grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
+grep -q 'pika' requirements.txt || echo "pika<0.11,>=0.9" >> requirements.txt
 sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0 # BSD/g" requirements.txt
 


### PR DESCRIPTION
The module pika-pool requires pika<0.11,>=0.9. However, pika 0.11.0 is installed by default. This issue seems to be temporary and so will modify the requirements.txt outside of Mistral git repo to workaround it.