### PR TITLE
Pin python-senlinclient to workaround openstacksdk conflict

### DIFF
--- a/actions/install.sh
+++ b/actions/install.sh
@@ -50,6 +50,7 @@ grep -q 'pika' requirements.txt || echo "pika<0.11,>=0.9" >> requirements.txt
 grep -q 'python-memcached' requirements.txt || echo "python-memcached" >> requirements.txt
 sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0 # BSD/g" requirements.txt
+sed -i "s/^python-senlinclient.*/python-senlinclient<1.10.0 # Apache-2.0/g" requirements.txt
 
 echo "===== Final contents of requirements.txt ====="
 cat requirements.txt


### PR DESCRIPTION
The latest python-senlinclient version 1.10.0 requires openstacksdk 0.24.0. This is in conflict to the openstacksdk 0.21.0 that is currently specified. Updating openstacksdk will lead to other dependency conflicts.