### PR TITLE
Deprecate Mistral

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **DEPRECATED!**  
+> # DEPRECATED! #
 > Mistral workflow engine is deprecated in favor of native StackStorm Orquesta Workflow Engine.  
 > Please use Orquesta instead: https://docs.stackstorm.com/orquesta/index.html
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **DEPRECATED!**  
+> Mistral workflow engine is deprecated in favor of native StackStorm Orquesta Workflow Engine.  
+> Please use Orquesta instead: https://docs.stackstorm.com/orquesta/index.html
+
 # mistral_dev
 StackStorm Pack to automate various operations related to Mistral development, tesing and relase
 


### PR DESCRIPTION
As part of the Mistral Deprecation game plan: StackStorm/st2#4762 add the Deprecation warning to the repo readme and archive it.